### PR TITLE
Fix errors in MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
 # Enforce UTF-8 encoding on MSVC.
 if (MSVC)
     target_compile_options(${PROJECT_NAME} PRIVATE /utf-8)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE _USE_MATH_DEFINES)  # Defines M_PI
 endif()
 
 # Enable warnings recommended for new projects.

--- a/src/core/asset.hpp
+++ b/src/core/asset.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <string>
 
 namespace dl

--- a/src/core/asset_manager.cpp
+++ b/src/core/asset_manager.cpp
@@ -19,7 +19,7 @@ AssetManager::AssetManager(const std::filesystem::path& filepath) : m_filepath(f
   m_base_dir.remove_filename();
 
   // Load config file
-  m_json.load(m_filepath);
+  m_json.load(m_filepath.string());
   m_init_assets();
 }
 

--- a/src/core/asset_manager.hpp
+++ b/src/core/asset_manager.hpp
@@ -30,7 +30,7 @@ class AssetManager
   {
     if (!m_assets.contains(id))
     {
-      spdlog::warn("There's no asset with ID {}.\n{}", id);
+      spdlog::warn("There's no asset with ID {}.\n", id);
       return nullptr;
     }
 

--- a/src/core/file_manager.cpp
+++ b/src/core/file_manager.cpp
@@ -36,6 +36,6 @@ std::filesystem::path FileManager::get_full_path(const std::string& relative_pat
 
 std::filesystem::path FileManager::get_script_path(const std::string& relative_path)
 {
-  return get_full_path(std::filesystem::path{"scripts"} / relative_path);
+  return get_full_path((std::filesystem::path{"scripts"} / relative_path).string());
 }
 }  // namespace dl

--- a/src/core/serialization.hpp
+++ b/src/core/serialization.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <entt/entity/fwd.hpp>
+#include <string>
 
 namespace dl
 {

--- a/src/core/thread_pool.hpp
+++ b/src/core/thread_pool.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <mutex>
 #include <queue>
 #include <thread>

--- a/src/debug/chunk_debugger.cpp
+++ b/src/debug/chunk_debugger.cpp
@@ -56,7 +56,10 @@ void ChunkDebugger::update()
                                                m_gameplay.m_world.chunk_manager.chunk_size.x * grid_size.x,
                                                m_gameplay.m_world.chunk_manager.chunk_size.y * grid_size.y,
                                                color);
-      m_gameplay.m_registry.emplace<Position>(entity, chunk->position.x, chunk->position.y, chunk->position.z);
+      m_gameplay.m_registry.emplace<Position>(entity,
+                                              static_cast<double>(chunk->position.x),
+                                              static_cast<double>(chunk->position.y),
+                                              static_cast<double>(chunk->position.z));
       chunk_quads.push_back(entity);
     }
   }

--- a/src/debug/general_info.cpp
+++ b/src/debug/general_info.cpp
@@ -1,10 +1,12 @@
 #include "./general_info.hpp"
 
+#ifdef __APPLE__
 #include <mach/mach.h>
-#include <stdlib.h>
 #include <sys/sysctl.h>
-#include <sys/types.h>
 #include <unistd.h>
+#endif
+#include <stdlib.h>
+#include <sys/types.h>
 
 #include <chrono>
 

--- a/src/debug/lib/imgui_impl_opengl3.cpp
+++ b/src/debug/lib/imgui_impl_opengl3.cpp
@@ -207,7 +207,7 @@
 #endif
 
 // [Debugging]
-//#define IMGUI_IMPL_OPENGL_DEBUG
+// #define IMGUI_IMPL_OPENGL_DEBUG
 #ifdef IMGUI_IMPL_OPENGL_DEBUG
 #include <stdio.h>
 #define GL_CALL(_CALL)                                                        \

--- a/src/ecs/systems/action.cpp
+++ b/src/ecs/systems/action.cpp
@@ -184,13 +184,16 @@ void ActionSystem::m_update_closed_menu(entt::registry& registry, const Camera& 
       }
 
       m_action_menu->set_actions(m_actions);
-      m_action_menu->set_on_select([this, &registry, mouse_tile, selected_entity](const uint32_t i) {
-        for (const auto entity : m_selected_entities)
-        {
-          m_create_job(static_cast<JobType>(i), static_cast<uint32_t>(selected_entity), mouse_tile, registry, entity);
-        }
-        m_dispose();
-      });
+      m_action_menu->set_on_select(
+          [this, &registry, mouse_tile, selected_entity](const uint32_t i)
+          {
+            for (const auto entity : m_selected_entities)
+            {
+              m_create_job(
+                  static_cast<JobType>(i), static_cast<uint32_t>(selected_entity), mouse_tile, registry, entity);
+            }
+            m_dispose();
+          });
       m_input_manager.push_context("action_menu"_hs);
       m_state = ActionMenuState::Open;
     }
@@ -206,13 +209,15 @@ void ActionSystem::m_update_closed_menu(entt::registry& registry, const Camera& 
       }
 
       m_action_menu->set_actions(m_actions);
-      m_action_menu->set_on_select([this, &registry, mouse_tile, &tile_data](const uint32_t i) {
-        for (const auto entity : m_selected_entities)
-        {
-          m_create_job(static_cast<JobType>(i), tile_data.id, mouse_tile, registry, entity);
-        }
-        m_dispose();
-      });
+      m_action_menu->set_on_select(
+          [this, &registry, mouse_tile, &tile_data](const uint32_t i)
+          {
+            for (const auto entity : m_selected_entities)
+            {
+              m_create_job(static_cast<JobType>(i), tile_data.id, mouse_tile, registry, entity);
+            }
+            m_dispose();
+          });
       m_input_manager.push_context("action_menu"_hs);
       m_state = ActionMenuState::Open;
     }

--- a/src/ecs/systems/action.hpp
+++ b/src/ecs/systems/action.hpp
@@ -66,8 +66,7 @@ class ActionSystem
                                 const entt::entity entity,
                                 entt::registry& registry);
   bool m_has_consumables(const std::map<uint32_t, uint32_t>& consumables, entt::registry& registry);
-  std::function<void(const uint32_t)> m_on_select_generic_action = [this](const uint32_t i) {
-    m_state = static_cast<ActionMenuState>(i);
-  };
+  std::function<void(const uint32_t)> m_on_select_generic_action = [this](const uint32_t i)
+  { m_state = static_cast<ActionMenuState>(i); };
 };
 }  // namespace dl

--- a/src/ecs/systems/drop.cpp
+++ b/src/ecs/systems/drop.cpp
@@ -122,7 +122,10 @@ void DropSystem::update(entt::registry& registry, const Camera& camera)
     if (removed)
     {
       auto& item_component = registry.get<Item>(item);
-      registry.emplace<Position>(item, target.position.x, target.position.y, target.position.z);
+      registry.emplace<Position>(item,
+                                 static_cast<double>(target.position.x),
+                                 static_cast<double>(target.position.y),
+                                 static_cast<double>(target.position.z));
       registry.emplace<Visibility>(item, m_world.get_texture_id(), item_component.id, "item", 1);
     }
 

--- a/src/ecs/systems/drop.cpp
+++ b/src/ecs/systems/drop.cpp
@@ -22,14 +22,16 @@
 
 namespace dl
 {
-const auto stop_drop = [](entt::registry& registry, const entt::entity entity, const Job* job) {
+const auto stop_drop = [](entt::registry& registry, const entt::entity entity, const Job* job)
+{
   registry.remove<ActionDrop>(entity);
   job->status = JobStatus::Finished;
 };
 
 DropSystem::DropSystem(World& world, ui::UIManager& ui_manager) : m_world(world), m_ui_manager(ui_manager)
 {
-  const auto on_select = [this](const ui::EntityPair entities) {
+  const auto on_select = [this](const ui::EntityPair entities)
+  {
     m_selected_entity = entities.first;
     m_target_item = entities.second;
     m_state = DropMenuState::SelectingTarget;

--- a/src/ecs/systems/physics.cpp
+++ b/src/ecs/systems/physics.cpp
@@ -17,126 +17,129 @@ PhysicsSystem::PhysicsSystem(World& world) : m_world(world) {}
 void PhysicsSystem::update(entt::registry& registry, const double delta)
 {
   auto view = registry.view<Biology, Position, Velocity>();
-  view.each([this, &registry, delta](auto entity, auto& biology, auto& position, auto& velocity) {
-    if (velocity.x == 0 && velocity.y == 0)
-    {
-      return;
-    }
-
-    biology.turn_threshold -= biology.speed * 1000.0 * delta;
-
-    if (biology.turn_threshold > 0.0)
-    {
-      return;
-    }
-
-    biology.turn_threshold = 200.0;
-
-    const auto speed_divide_factor = 100.0;
-    const auto position_variation = (biology.speed / speed_divide_factor);
-
-    Position candidate_position{
-        position.x + velocity.x * position_variation,
-        position.y + velocity.y * position_variation,
-        position.z,
-    };
-
-    Position target_position = Position{position};
-
-    Vector2i absolute_advance{
-        std::abs(std::round(candidate_position.x) - std::round(position.x)),
-        std::abs(std::round(candidate_position.y) - std::round(position.y)),
-    };
-
-    // Test collision for the tiles we want advance
-    if (absolute_advance.x > 0 || absolute_advance.y > 0)
-    {
-      bool distant_collide = false;
-      auto last_position_x = position.x;
-      auto last_position_y = position.y;
-
-      TCOD_bresenham_data_t bresenham_data;
-      int x_round = std::round(position.x);
-      int y_round = std::round(position.y);
-
-      TCOD_line_init_mt(x_round,
-                        y_round,
-                        x_round + absolute_advance.x * velocity.x,
-                        y_round + absolute_advance.y * velocity.y,
-                        &bresenham_data);
-
-      // While loop instead of do while to avoid checking the current position
-      while (!TCOD_line_step_mt(&x_round, &y_round, &bresenham_data))
+  view.each(
+      [this, &registry, delta](auto entity, auto& biology, auto& position, auto& velocity)
       {
-        distant_collide = m_collides(registry, entity, x_round, y_round, candidate_position.z);
-
-        if (distant_collide)
+        if (velocity.x == 0 && velocity.y == 0)
         {
-          break;
+          return;
         }
-        last_position_x = x_round;
-        last_position_y = y_round;
-      }
 
-      // Confirm position if there was no collision
-      if (!distant_collide)
-      {
-        target_position.x = candidate_position.x;
-        target_position.y = candidate_position.y;
-      }
-      // Otherwise, advance to the last walkable position
-      // if it's not the current position.
-      else
-      {
-        const auto walkable_advance_x = std::abs(last_position_x - position.x);
-        const auto walkable_advance_y = std::abs(last_position_y - position.y);
+        biology.turn_threshold -= biology.speed * 1000.0 * delta;
 
-        // Entity can move to a position that is closer than the target
-        if (walkable_advance_x > 0 || walkable_advance_y > 0)
+        if (biology.turn_threshold > 0.0)
         {
-          target_position.x = position.x + walkable_advance_x * velocity.x;
-          target_position.y = position.y + walkable_advance_y * velocity.y;
+          return;
         }
-        // Entity collided and can't advance
-        else
-        {
-          const auto climb_position = m_get_climb_position(position, candidate_position);
-          const auto& tile_data = m_world.get_terrain(climb_position.x, climb_position.y, climb_position.z);
 
-          if (tile_data.flags.contains("WALKABLE"))
+        biology.turn_threshold = 200.0;
+
+        const auto speed_divide_factor = 100.0;
+        const auto position_variation = (biology.speed / speed_divide_factor);
+
+        Position candidate_position{
+            position.x + velocity.x * position_variation,
+            position.y + velocity.y * position_variation,
+            position.z,
+        };
+
+        Position target_position = Position{position};
+
+        Vector2i absolute_advance{
+            std::abs(std::round(candidate_position.x) - std::round(position.x)),
+            std::abs(std::round(candidate_position.y) - std::round(position.y)),
+        };
+
+        // Test collision for the tiles we want advance
+        if (absolute_advance.x > 0 || absolute_advance.y > 0)
+        {
+          bool distant_collide = false;
+          auto last_position_x = position.x;
+          auto last_position_y = position.y;
+
+          TCOD_bresenham_data_t bresenham_data;
+          int x_round = std::round(position.x);
+          int y_round = std::round(position.y);
+
+          TCOD_line_init_mt(x_round,
+                            y_round,
+                            x_round + absolute_advance.x * velocity.x,
+                            y_round + absolute_advance.y * velocity.y,
+                            &bresenham_data);
+
+          // While loop instead of do while to avoid checking the current position
+          while (!TCOD_line_step_mt(&x_round, &y_round, &bresenham_data))
           {
-            target_position = climb_position;
+            distant_collide = m_collides(registry, entity, x_round, y_round, candidate_position.z);
+
+            if (distant_collide)
+            {
+              break;
+            }
+            last_position_x = x_round;
+            last_position_y = y_round;
           }
+
+          // Confirm position if there was no collision
+          if (!distant_collide)
+          {
+            target_position.x = candidate_position.x;
+            target_position.y = candidate_position.y;
+          }
+          // Otherwise, advance to the last walkable position
+          // if it's not the current position.
           else
           {
-            const auto& target_tile = m_world.get_all(
-                std::round(candidate_position.x), std::round(candidate_position.y), std::round(candidate_position.z));
+            const auto walkable_advance_x = std::abs(last_position_x - position.x);
+            const auto walkable_advance_y = std::abs(last_position_y - position.y);
 
-            // Empty tile, fall down
-            if (target_tile.terrain.id == 0)
+            // Entity can move to a position that is closer than the target
+            if (walkable_advance_x > 0 || walkable_advance_y > 0)
             {
-              candidate_position.z -= 1;
-              target_position = candidate_position;
+              target_position.x = position.x + walkable_advance_x * velocity.x;
+              target_position.y = position.y + walkable_advance_y * velocity.y;
+            }
+            // Entity collided and can't advance
+            else
+            {
+              const auto climb_position = m_get_climb_position(position, candidate_position);
+              const auto& tile_data = m_world.get_terrain(climb_position.x, climb_position.y, climb_position.z);
+
+              if (tile_data.flags.contains("WALKABLE"))
+              {
+                target_position = climb_position;
+              }
+              else
+              {
+                const auto& target_tile = m_world.get_all(std::round(candidate_position.x),
+                                                          std::round(candidate_position.y),
+                                                          std::round(candidate_position.z));
+
+                // Empty tile, fall down
+                if (target_tile.terrain.id == 0)
+                {
+                  candidate_position.z -= 1;
+                  target_position = candidate_position;
+                }
+              }
             }
           }
         }
-      }
-    }
-    // If there was a fractional advance without tile change, just update our position
-    else
-    {
-      target_position = candidate_position;
-    }
+        // If there was a fractional advance without tile change, just update our position
+        else
+        {
+          target_position = candidate_position;
+        }
 
-    // Update the position if it's different from the last position
-    if (target_position.x != position.x || target_position.y != position.y || target_position.z != position.z)
-    {
-      registry.patch<Position>(entity, [&target_position](auto& position) { position = target_position; });
-    }
+        // Update the position if it's different from the last position
+        if (target_position.x != position.x || target_position.y != position.y || target_position.z != position.z)
+        {
+          registry.patch<Position>(entity, [&target_position](auto& position) { position = target_position; });
+        }
 
-    velocity.x = 0.;
-    velocity.y = 0.;
-  });
+        velocity.x = 0.;
+        velocity.y = 0.;
+      });
 }
 
 bool PhysicsSystem::m_collides(entt::registry& registry, entt::entity entity, const int x, const int y, const int z)

--- a/src/ecs/systems/pickup.cpp
+++ b/src/ecs/systems/pickup.cpp
@@ -13,7 +13,8 @@
 
 namespace dl
 {
-const auto stop_pickup = [](entt::registry& registry, const entt::entity entity, const Job* job) {
+const auto stop_pickup = [](entt::registry& registry, const entt::entity entity, const Job* job)
+{
   registry.remove<ActionPickup>(entity);
   job->status = JobStatus::Finished;
 };

--- a/src/ecs/systems/render.hpp
+++ b/src/ecs/systems/render.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <entt/entity/fwd.hpp>
+#include <string>
 #include <unordered_map>
 
 #include "graphics/tile_render_data.hpp"

--- a/src/ecs/systems/society.cpp
+++ b/src/ecs/systems/society.cpp
@@ -20,83 +20,87 @@ SocietySystem::SocietySystem() {}
 void SocietySystem::update(entt::registry& registry, const double delta)
 {
   auto view = registry.view<SocietyAgent>();
-  view.each([&registry, delta](auto entity, auto& agent) {
-    if (agent.state == SocietyAgent::State::Harvesting)
-    {
-      /* if (!registry.all_of<ActionHarvest>(entity)) */
-      /* { */
-      /*   registry.emplace<ActionHarvest>(entity); */
-      /* } */
-    }
-    else if (agent.state == SocietyAgent::State::Idle)
-    {
-      if (agent.time_to_next_action <= 0)
+  view.each(
+      [&registry, delta](auto entity, auto& agent)
       {
-        agent.time_to_next_action = 1.0;
-        /* const auto n = random::get_real(); */
-
-        /* if (n < .7f) */
-        /* { */
-        /*   agent.state = SocietyAgent::State::Walking; */
-        /* } */
-      }
-      else
-      {
-        agent.time_to_next_action -= delta;
-      }
-    }
-    else if (agent.state == SocietyAgent::State::Walking || agent.state == SocietyAgent::State::Idle)
-    {
-      if (agent.time_to_next_action <= 0)
-      {
-        agent.time_to_next_action = 1.0;
-        const auto n = random::get_real();
-        if (n < .4f)
+        if (agent.state == SocietyAgent::State::Harvesting)
         {
-          agent.state = SocietyAgent::State::Idle;
+          /* if (!registry.all_of<ActionHarvest>(entity)) */
+          /* { */
+          /*   registry.emplace<ActionHarvest>(entity); */
+          /* } */
         }
-      }
-      else
-      {
-        agent.time_to_next_action -= delta;
-      }
+        else if (agent.state == SocietyAgent::State::Idle)
+        {
+          if (agent.time_to_next_action <= 0)
+          {
+            agent.time_to_next_action = 1.0;
+            /* const auto n = random::get_real(); */
 
-      const auto x_dir = random::get_real();
-      const auto y_dir = random::get_real();
+            /* if (n < .7f) */
+            /* { */
+            /*   agent.state = SocietyAgent::State::Walking; */
+            /* } */
+          }
+          else
+          {
+            agent.time_to_next_action -= delta;
+          }
+        }
+        else if (agent.state == SocietyAgent::State::Walking || agent.state == SocietyAgent::State::Idle)
+        {
+          if (agent.time_to_next_action <= 0)
+          {
+            agent.time_to_next_action = 1.0;
+            const auto n = random::get_real();
+            if (n < .4f)
+            {
+              agent.state = SocietyAgent::State::Idle;
+            }
+          }
+          else
+          {
+            agent.time_to_next_action -= delta;
+          }
 
-      auto velocity_x = 0.;
-      auto velocity_y = 0.;
+          const auto x_dir = random::get_real();
+          const auto y_dir = random::get_real();
 
-      if (x_dir < .33f)
-      {
-        velocity_x = -1.0;
-      }
-      else if (x_dir < .66f)
-      {
-        velocity_x = 1.0;
-      }
+          auto velocity_x = 0.;
+          auto velocity_y = 0.;
 
-      if (y_dir < .33f)
-      {
-        velocity_y = -1.0;
-      }
-      else if (y_dir < .66f)
-      {
-        velocity_y = 1.0;
-      }
+          if (x_dir < .33f)
+          {
+            velocity_x = -1.0;
+          }
+          else if (x_dir < .66f)
+          {
+            velocity_x = 1.0;
+          }
 
-      if (registry.all_of<Velocity>(entity))
-      {
-        registry.patch<Velocity>(entity, [velocity_x, velocity_y](auto& velocity) {
-          velocity.x = velocity_x;
-          velocity.y = velocity_y;
-        });
-      }
-      else
-      {
-        registry.emplace<Velocity>(entity, velocity_x, velocity_y, 0.);
-      }
-    }
-  });
+          if (y_dir < .33f)
+          {
+            velocity_y = -1.0;
+          }
+          else if (y_dir < .66f)
+          {
+            velocity_y = 1.0;
+          }
+
+          if (registry.all_of<Velocity>(entity))
+          {
+            registry.patch<Velocity>(entity,
+                                     [velocity_x, velocity_y](auto& velocity)
+                                     {
+                                       velocity.x = velocity_x;
+                                       velocity.y = velocity_y;
+                                     });
+          }
+          else
+          {
+            registry.emplace<Velocity>(entity, velocity_x, velocity_y, 0.);
+          }
+        }
+      });
 }
 }  // namespace dl

--- a/src/ecs/systems/walk.cpp
+++ b/src/ecs/systems/walk.cpp
@@ -10,7 +10,8 @@
 
 namespace dl
 {
-const auto stop_walk = [](entt::registry& registry, const entt::entity entity, const Job* job) {
+const auto stop_walk = [](entt::registry& registry, const entt::entity entity, const Job* job)
+{
   registry.remove<ActionWalk>(entity);
   registry.remove<WalkPath>(entity);
   job->status = JobStatus::Finished;
@@ -61,10 +62,12 @@ void WalkSystem::update(entt::registry& registry)
 
       if (registry.all_of<Velocity>(entity))
       {
-        registry.patch<Velocity>(entity, [x_dir, y_dir](auto& velocity) {
-          velocity.x = x_dir;
-          velocity.y = y_dir;
-        });
+        registry.patch<Velocity>(entity,
+                                 [x_dir, y_dir](auto& velocity)
+                                 {
+                                   velocity.x = x_dir;
+                                   velocity.y = y_dir;
+                                 });
       }
       else
       {

--- a/src/ecs/systems/wear.cpp
+++ b/src/ecs/systems/wear.cpp
@@ -11,7 +11,8 @@
 
 namespace dl
 {
-const auto stop_wear = [](entt::registry& registry, const entt::entity entity, const Job* job) {
+const auto stop_wear = [](entt::registry& registry, const entt::entity entity, const Job* job)
+{
   registry.remove<ActionWear>(entity);
   job->status = JobStatus::Finished;
 };

--- a/src/ecs/systems/wield.cpp
+++ b/src/ecs/systems/wield.cpp
@@ -11,7 +11,8 @@
 
 namespace dl
 {
-const auto stop_wield = [](entt::registry& registry, const entt::entity entity, const Job* job) {
+const auto stop_wield = [](entt::registry& registry, const entt::entity entity, const Job* job)
+{
   registry.remove<ActionWield>(entity);
   job->status = JobStatus::Finished;
 };

--- a/src/graphics/renderer.cpp
+++ b/src/graphics/renderer.cpp
@@ -20,9 +20,9 @@ void Renderer::add_batch(const uint32_t batch_id, const std::string& shader_id, 
   auto batch = std::make_unique<Batch>(shader_id, priority);
 
   m_ordered_batches.push_back(batch.get());
-  std::sort(m_ordered_batches.begin(), m_ordered_batches.end(), [](const auto& lhs, const auto& rhs) {
-    return lhs->priority < rhs->priority;
-  });
+  std::sort(m_ordered_batches.begin(),
+            m_ordered_batches.end(),
+            [](const auto& lhs, const auto& rhs) { return lhs->priority < rhs->priority; });
 
   m_batches.emplace(batch_id, std::move(batch));
 }
@@ -31,9 +31,9 @@ void Renderer::add_batch(Batch* batch)
 {
   m_ordered_batches.push_back(batch);
 
-  std::sort(m_ordered_batches.begin(), m_ordered_batches.end(), [](const auto& lhs, const auto& rhs) {
-    return lhs->priority < rhs->priority;
-  });
+  std::sort(m_ordered_batches.begin(),
+            m_ordered_batches.end(),
+            [](const auto& lhs, const auto& rhs) { return lhs->priority < rhs->priority; });
 }
 
 std::shared_ptr<Texture> Renderer::get_texture(const std::string& resource_id)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,4 +6,5 @@ int main()
 
   game.load();
   game.run();
+  return 0;
 }

--- a/src/ui/components/component.hpp
+++ b/src/ui/components/component.hpp
@@ -92,9 +92,9 @@ class UIComponent
   template <typename T, typename... Args>
   void erase(const T* component)
   {
-    children.erase(std::find_if(children.begin(), children.end(), [component](std::unique_ptr<UIComponent>& c) {
-      return c.get() == component;
-    }));
+    children.erase(std::find_if(children.begin(),
+                                children.end(),
+                                [component](std::unique_ptr<UIComponent>& c) { return c.get() == component; }));
   }
 
   template <typename T, typename... Args>

--- a/src/world/chunk_manager.cpp
+++ b/src/world/chunk_manager.cpp
@@ -89,14 +89,18 @@ void ChunkManager::update(const Vector3i& target)
     const auto target_chunk_position = world_to_chunk(target);
 
     // Activate / Deactivate chunks within a certain radius
-    activate_if([this, &target_chunk_position](const auto& chunk) {
-      return is_within_tile_distance(chunk->position, target_chunk_position, Vector2i{frustum.x * 2, frustum.y * 2});
-    });
+    activate_if(
+        [this, &target_chunk_position](const auto& chunk) {
+          return is_within_tile_distance(
+              chunk->position, target_chunk_position, Vector2i{frustum.x * 2, frustum.y * 2});
+        });
 
     // Unload chunks within a certain radius
-    std::erase_if(chunks, [this, &target_chunk_position](const auto& chunk) {
-      return !is_within_tile_distance(chunk->position, target_chunk_position, Vector2i{frustum.x * 4, frustum.y * 4});
-    });
+    std::erase_if(chunks,
+                  [this, &target_chunk_position](const auto& chunk) {
+                    return !is_within_tile_distance(
+                        chunk->position, target_chunk_position, Vector2i{frustum.x * 4, frustum.y * 4});
+                  });
   }
 
   {
@@ -122,9 +126,9 @@ bool ChunkManager::is_loaded(const Vector3i& position) const
       chunks.begin(), chunks.end(), [&position](const auto& chunk) { return chunk->position == position; });
 
   const auto found_generating =
-      std::find_if(m_chunks_loading.begin(), m_chunks_loading.end(), [&position](const auto& chunk_position) {
-        return position == chunk_position;
-      });
+      std::find_if(m_chunks_loading.begin(),
+                   m_chunks_loading.end(),
+                   [&position](const auto& chunk_position) { return position == chunk_position; });
 
   return found != chunks.end() || found_generating != m_chunks_loading.end();
 }
@@ -132,15 +136,14 @@ bool ChunkManager::is_loaded(const Vector3i& position) const
 void ChunkManager::load_async(const Vector3i& position)
 {
   const auto found =
-      std::find_if(m_chunks_loading.begin(), m_chunks_loading.end(), [&position](const Vector3i& generating_position) {
-        return generating_position == position;
-      });
+      std::find_if(m_chunks_loading.begin(),
+                   m_chunks_loading.end(),
+                   [&position](const Vector3i& generating_position) { return generating_position == position; });
 
   if (found == m_chunks_loading.end())
   {
-    m_thread_pool.queue_job([this, position, size = this->chunk_size] {
-      generate_async(std::ref(position), std::ref(size), std::ref(m_chunks_to_add_mutex));
-    });
+    m_thread_pool.queue_job([this, position, size = this->chunk_size]
+                            { generate_async(std::ref(position), std::ref(size), std::ref(m_chunks_to_add_mutex)); });
     m_chunks_loading.push_back(position);
   }
 }
@@ -165,9 +168,9 @@ void ChunkManager::generate_async(const Vector3i& position, const Vector3i& size
 void ChunkManager::load_sync(const Vector3i& position)
 {
   const auto found =
-      std::find_if(m_chunks_loading.begin(), m_chunks_loading.end(), [&position](const Vector3i& generating_position) {
-        return generating_position == position;
-      });
+      std::find_if(m_chunks_loading.begin(),
+                   m_chunks_loading.end(),
+                   [&position](const Vector3i& generating_position) { return generating_position == position; });
 
   if (found == m_chunks_loading.end())
   {
@@ -217,9 +220,9 @@ Chunk& ChunkManager::at(const int x, const int y, const int z) const
 {
   const Vector3i chunk_position = world_to_chunk(x, y, z);
 
-  const auto chunk = std::find_if(chunks.begin(), chunks.end(), [&chunk_position](const auto& chunk) {
-    return (chunk->position == chunk_position);
-  });
+  const auto chunk = std::find_if(chunks.begin(),
+                                  chunks.end(),
+                                  [&chunk_position](const auto& chunk) { return (chunk->position == chunk_position); });
 
   /* assert(chunk != chunks.end() && "Chunk should be already generated during update"); */
 
@@ -239,9 +242,9 @@ Chunk& ChunkManager::in(const int x, const int y, const int z) const
 {
   const Vector3i chunk_position = world_to_chunk(x, y, z);
 
-  const auto chunk = std::find_if(chunks.begin(), chunks.end(), [&chunk_position](const auto& chunk) {
-    return (chunk->position == chunk_position);
-  });
+  const auto chunk = std::find_if(chunks.begin(),
+                                  chunks.end(),
+                                  [&chunk_position](const auto& chunk) { return (chunk->position == chunk_position); });
 
   if (chunk != chunks.end())
   {

--- a/src/world/chunk_manager.hpp
+++ b/src/world/chunk_manager.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <mutex>
 #include <vector>
 

--- a/src/world/generators/terrain_generator.cpp
+++ b/src/world/generators/terrain_generator.cpp
@@ -389,7 +389,8 @@ std::vector<Point<int>> TerrainGenerator::m_get_coastline(const std::vector<int>
     const auto bottom_point = current_point.bottom();
     const auto top_point = current_point.top();
 
-    auto manipulate_point = [this, mask_size, &mask, &point_queue, &tiles](const Point<int>& point) {
+    auto manipulate_point = [this, mask_size, &mask, &point_queue, &tiles](const Point<int>& point)
+    {
       if (m_valid_point(point) && m_is_coast_point(point, tiles) &&
           mask[point.y * m_width + point.x] == TileType::Water)
       {
@@ -1239,7 +1240,8 @@ std::pair<Point<int>, Point<int>> TerrainGenerator::m_get_river_source_and_mouth
   std::size_t tries = 0;
 
   // Check if line crosses sea water to avoid unrealistic rivers
-  auto intersects_water = [this, &island](const Point<int>& source, const Point<int>& mouth) {
+  auto intersects_water = [this, &island](const Point<int>& source, const Point<int>& mouth)
+  {
     int tolerance = 4;
     int x = source.x;
     int y = source.y;

--- a/src/world/society/name_generator.cpp
+++ b/src/world/society/name_generator.cpp
@@ -20,7 +20,7 @@ void NameGenerator::load(const std::string& key)
   }
 
   const auto& filepath = m_json.object[key].get<std::string>();
-  m_weights.load(m_base_path / filepath);
+  m_weights.load((m_base_path / filepath).string());
 }
 
 std::string NameGenerator::generate()

--- a/src/world/society/name_generator.hpp
+++ b/src/world/society/name_generator.hpp
@@ -19,7 +19,7 @@ class NameGenerator
 
  private:
   static const std::filesystem::path m_base_path;
-  JSON m_json{m_base_path / "index.json"};
+  JSON m_json{(m_base_path / "index.json").string()};
   JSON m_weights;
   const size_t m_max_tries = 5;
   const size_t m_max_internal_tries = 10;

--- a/src/world/society/society_blueprint.hpp
+++ b/src/world/society/society_blueprint.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <string>
 #include <unordered_map>
 

--- a/src/world/world.cpp
+++ b/src/world/world.cpp
@@ -434,7 +434,7 @@ entt::entity World::create_item(
   const auto item = item_factory::create(get_item_data(id), registry);
 
   registry.emplace<Visibility>(item, get_texture_id(), id, "item", 1);
-  registry.emplace<Position>(item, x, y, z);
+  registry.emplace<Position>(item, static_cast<double>(x), static_cast<double>(y), static_cast<double>(z));
   return item;
 }
 

--- a/src/world/world.hpp
+++ b/src/world/world.hpp
@@ -2,6 +2,7 @@
 
 #include <entt/entity/entity.hpp>
 #include <map>
+#include <stack>
 #include <vector>
 
 #include "./chunk_manager.hpp"


### PR DESCRIPTION
The sources were not already clang-formatted which messed up my PR when I used the formatting script, I've separated the formatting into a separate commit.

I could not fix issues with `TextureLoader`, `ShaderLoader`, and `FontLoader`. It looks like the constructors were changed but the calls were not updated. This issue has prevented me from fully compiling the project.

There's a MacOS file had includes not supported on Windows, I've moved those into `#ifdef __APPLE__` but I'm not 100% sure on those.

I resolved some conversion issues: int does not convert fully into double, and paths do not always implicitly convert to strings.

I've added several missing header includes, and fixed a malformed format string.