### PR TITLE
Refactor run.py

### DIFF
--- a/run.py
+++ b/run.py
@@ -23,12 +23,7 @@ def build(build_path: Path) -> None:
     subprocess.run(['cmake', '--build', build_path], check=True)
 
 def run(target_path: Path, data_path: Path) -> None:
-    build_data_path = target_path / DATA_DIR_NAME
-
-    if build_data_path.exists():
-        shutil.rmtree(build_data_path)
-    shutil.copytree(data_path, build_data_path)
-    subprocess.run([target_path / TARGET_NAME], check=True, cwd=target_path)
+    subprocess.run([target_path / TARGET_NAME], check=True, cwd=THIS_DIR)
 
 def format() -> None:
     source_dir = THIS_DIR / "src"


### PR DESCRIPTION
`make` is not portable, not all `cmake` generators use it.

Replaced all calls to `os.system` with the more maintainable `subprocess.run`. This also removes the need to change directories with `os.chdir`.

Removed `-j 4`, `cmake` does have this flag but it's probably better to set an environment variable for your system rather than just asking Python how many CPU's the computer has. See [CMAKE_BUILD_PARALLEL_LEVEL](https://cmake.org/cmake/help/latest/envvar/CMAKE_BUILD_PARALLEL_LEVEL.html).

The format function is a lot better and I did test this. Excluding the generators lib folder is not necessary since `clang-format` is already configured to ignore it.

You can ask me to make more changes or revert anything. Or reject this PR, I ended up messing around more than necessary.

Renamed some functions: `build` was only doing configuration, and I refactored `make` to build no matter which generator was used.

I noticed code to run the project copies the `data` folder to the `bin` directory and then runs the program, but that isn't necessary. I'd actually recommend simply changing the working directly to the project root where the data already is and then running the executable in the `bin` directory, nothing needs to be copied until distribution.

The script default behavior looks very strange to me. I assume you had a good reason for configuring the project without making it and then running it. Perhaps to deal with how weird Vcpkg is sometimes.

Also the CLI flags are odd. Configure/build/run should be single flags doing only their own thing.